### PR TITLE
Replace Validation Summary With Placeholders

### DIFF
--- a/src/PasswordManager.App/Content/base-theme.css
+++ b/src/PasswordManager.App/Content/base-theme.css
@@ -124,7 +124,7 @@ textarea {
 }
 
 .profile-btn-group {
-    width: 100%;
+    width: 80%;
     margin: auto;
     display: flex;
     justify-content: flex-end;
@@ -158,7 +158,7 @@ textarea {
     width: 90%;
     margin: 6px auto;
     display: grid !important;
-    grid-template-columns: 2fr 1fr;
+    grid-template-columns: 1fr;
     grid-gap: 10px;
     justify-content: center;
 }
@@ -344,3 +344,18 @@ textarea {
     }
 }
 /*#endregion */
+
+::placeholder {
+    font-style: italic;
+    color: darkred;
+    opacity: 0.6;
+}
+
+:disabled {
+    opacity: 0.5;
+}
+
+:disabled:hover {
+    background-color: transparent;
+    color: var(--primary-text);
+}

--- a/src/PasswordManager.App/Scripts/main.js
+++ b/src/PasswordManager.App/Scripts/main.js
@@ -7,6 +7,33 @@ let editForm; // Profile details for value reversion in case of edit cancel
 
 collapseAll();
 linkCategoriesToProfiles();
+linkProfileTitlesToSubmitBtns();
+
+// When input for title textbox changes, the submit button is toggled 'disabled' depending on whether input exists
+function linkProfileTitlesToSubmitBtns() {
+    const groups = Array.from(document.querySelectorAll('.profile-edit-group'));
+
+    groups.forEach(group => {
+        const titleBox = group.querySelector('.profile-titlebox');
+        const submitBtn = group.querySelector('.profile-submit');
+        
+        titleBox.addEventListener('input', e => {
+            checkTextboxForValue(titleBox, submitBtn);
+        });
+
+        checkTextboxForValue(titleBox, submitBtn)
+    });
+}
+
+// Disables input if textbox is empty
+function checkTextboxForValue(textbox, inputBtn) {
+    if (textbox.value === "" || textbox.value.trim() === "") {
+        inputBtn.disabled = true;
+    }
+    else {
+        inputBtn.disabled = false;
+    }
+}
 
 // Resizes category max-height when child profile tabs are opened/closed
 function linkCategoriesToProfiles() {
@@ -23,6 +50,7 @@ function linkCategoriesToProfiles() {
     });
 }
 
+// Toggles visibility of profiles under specific category
 // param: liParentOffset => Indicates steps from button to reach parent li element
 function onCategoryClick(button, liParentOffset = 2) {
     const listParent = getParent(button, liParentOffset);
@@ -30,6 +58,7 @@ function onCategoryClick(button, liParentOffset = 2) {
     toggleView(group);
 };
 
+// Toggles visibility of clicked profile and previouse profile
 // param: liParentOffset => Indicates steps from button to reach parent li element
 function onProfileClick(button, liParentOffset = 2) {
     // Cancel any in progress editing
@@ -89,9 +118,9 @@ function onCancelEditClick() {
     editView.querySelector("#LoginName").value = editForm.LoginName;
     editView.querySelector("#Password").value = editForm.Password;
     editView.querySelector("#SignUpEmail").value = editForm.SignUpEmail;
-    // Clear validation summary
-    const summaryList = editView.querySelector(".form-message").querySelector("ul");
-    summaryList.innerHTML = "";
+    // Clear validation summary -> Validation Summary Not Currently in HTML
+    //const summaryList = editView.querySelector(".form-message").querySelector("ul");
+    //summaryList.innerHTML = "";
 }
 
 function getParent(item, steps) {

--- a/src/PasswordManager.App/Views/Profile/_CreatePartial.cshtml
+++ b/src/PasswordManager.App/Views/Profile/_CreatePartial.cshtml
@@ -3,13 +3,13 @@
 @Scripts.Render("~/bundles/jquery")
 @Scripts.Render("~/bundles/jqueryval")
 
-@using (Html.BeginForm("Create", "Profile", FormMethod.Post, new { @class = "profile-detail-group" }))
+@using (Html.BeginForm("Create", "Profile", FormMethod.Post, new { @class = "profile-detail-group profile-edit-group" }))
 {
     @Html.AntiForgeryToken()
 
     <div class="profile-details">
         <h4>@Html.LabelFor(model => model.Title):</h4>
-        @Html.EditorFor(m => m.Title, new { htmlAttributes = new { @class = "profile-textbox" } })
+        @Html.EditorFor(m => m.Title, new { htmlAttributes = new { @class = "profile-textbox profile-titlebox", @placeholder = "Title Required" } })
 
         <h4>@Html.LabelFor(model => model.Category):</h4>
         @Html.DropDownListFor(m => m.Category, (List<SelectListItem>)ViewBag.categoryItems, new { @class = "profile-textbox" })
@@ -27,9 +27,9 @@
         @Html.EditorFor(m => m.SignUpEmail,  new { htmlAttributes = new { @class = "profile-textbox" } })
     </div>
 
-    @Html.ValidationSummary(false, "", new { @class = "form-message" })
+    @*Html.ValidationSummary(false, "", new { @class = "form-message" })*@
 
     <div class="profile-btn-group">
-        <input type="submit" value="Create" class="profile-btn" />
+        <input type="submit" value="Create" class="profile-btn profile-submit" />
     </div>
 }

--- a/src/PasswordManager.App/Views/Profile/_EditPartial.cshtml
+++ b/src/PasswordManager.App/Views/Profile/_EditPartial.cshtml
@@ -9,7 +9,7 @@
 
     <div class="profile-details">
         <h4>@Html.LabelFor(model => model.Title):</h4>
-        @Html.EditorFor(m => m.Title,  new { htmlAttributes = new { @class = "profile-textbox" } })
+        @Html.EditorFor(m => m.Title,  new { htmlAttributes = new { @class = "profile-textbox profile-titlebox", @placeholder = "Title Required" } })
 
         <h4>@Html.LabelFor(model => model.Category):</h4>
         @Html.DropDownListFor(m => m.Category, (List<SelectListItem>)ViewBag.categoryItems, new { @class = "profile-textbox" })
@@ -27,11 +27,10 @@
         @Html.EditorFor(m => m.SignUpEmail,  new { htmlAttributes = new { @class = "profile-textbox" } })
     </div>
 
-    @Html.ValidationSummary(false, "", new { @class = "form-message" })
+    @*Html.ValidationSummary(false, "", new { @class = "form-message" })*@
 
     <div class="profile-btn-group">
-        <button type="button" class="profile-btn" onclick="">Generate Password</button>
         <button type="button" class="profile-btn" onclick="onCancelEditClick()">Cancel</button>
-        <input type="submit" value="Save" class="profile-btn save-btn" />
+        <input type="submit" value="Save" class="profile-btn profile-submit" />
     </div>
 }


### PR DESCRIPTION
Situation:
  Only one field in a profile is required to have content: the title. Having a html segment carved out for validation summary is unnecessary.

Solution:
  Removed the validation summary and added a placeholder text to the title textboxes indicating it as a required field. The create & save buttons are only enabled once the title field has at least one non-whitespace character.

Misc:
  Added 'Generate Password' buttons to edit forms for future functionality to be added.