### PR TITLE
Fix Encryption Bug That Prevented Password Retrieval

### DIFF
--- a/lib/PasswordManager.Library/DataAccess/ProfileData.cs
+++ b/lib/PasswordManager.Library/DataAccess/ProfileData.cs
@@ -1,6 +1,7 @@
 ﻿using PasswordManager.Library.Internal.DataAccess;
 using PasswordManager.Library.Internal.Encryption;
 using PasswordManager.Library.Models;
+using System;
 using System.Collections.Generic;
 
 namespace PasswordManager.Library.DataAccess
@@ -18,12 +19,12 @@ namespace PasswordManager.Library.DataAccess
         {
             object sqlParams = new { @userId = userId };
 
-            IEnumerable<ProfileDataModel> data = _dataAccess.LoadData<ProfileDataModel>(DboNames.spGetProfilesByUser, DboNames.dboName, sqlParams);
+            IEnumerable<ProfileDataModel> data = _dataAccess.LoadData<ProfileDataModel>(DboNames.spGetProfilesByUser, DboNames.dboNameAzure, sqlParams);
 
             // Decrypt and reassign profile passwords
             foreach(var profile in data)
             {
-                profile.Password = ProfileEncrypter.DecryptPassword(profile.Password, profile.Id);
+                profile.Password = ProfileEncrypter.DecryptPassword(profile.Password, profile.UserId);
             }
 
             return data;
@@ -31,7 +32,7 @@ namespace PasswordManager.Library.DataAccess
 
         public void InsertProfileForUser(ProfileDataModel data)
         {
-            data.Password = ProfileEncrypter.EncryptPassword(data.Password, data.Id);
+            data.Password = ProfileEncrypter.EncryptPassword(data.Password, data.UserId);
 
             object sqlParams = new
             {
@@ -44,12 +45,12 @@ namespace PasswordManager.Library.DataAccess
                 @signUpEmail = data.SignUpEmail
             };
 
-            _dataAccess.SaveData(DboNames.spInsertProfileByUser, DboNames.dboName, sqlParams);
+            _dataAccess.SaveData(DboNames.spInsertProfileByUser, DboNames.dboNameAzure, sqlParams);
         }
 
         public void UpdateProfile(ProfileDataModel data)
         {
-            data.Password = ProfileEncrypter.EncryptPassword(data.Password, data.Id);
+            data.Password = ProfileEncrypter.EncryptPassword(data.Password, data.UserId);
 
             object sqlParams = new
             {
@@ -63,12 +64,12 @@ namespace PasswordManager.Library.DataAccess
                 @lastUpdated = data.LastUpdated
             };
 
-            _dataAccess.SaveData(DboNames.spUpdateProfile, DboNames.dboName, sqlParams);
+            _dataAccess.SaveData(DboNames.spUpdateProfile, DboNames.dboNameAzure, sqlParams);
         }
 
         public void DeleteProfile(int id)
         {
-            _dataAccess.SaveData(DboNames.spDeleteProfile, DboNames.dboName, new { @id = id });
+            _dataAccess.SaveData(DboNames.spDeleteProfile, DboNames.dboNameAzure, new { @id = id });
         }
     }
 }

--- a/lib/PasswordManager.Library/Internal/Encrypters/ProfileEncrypter.cs
+++ b/lib/PasswordManager.Library/Internal/Encrypters/ProfileEncrypter.cs
@@ -12,10 +12,15 @@ namespace PasswordManager.Library.Internal.Encryption
 {
     internal static class ProfileEncrypter
     {
-        public static string EncryptPassword(string profilePassword, int profileId)
+        public static string EncryptPassword(string profilePassword, string userId)
         {
+            if (string.IsNullOrEmpty(userId))
+            {
+                throw new ArgumentException("Cannot encrypt password without proper userId.");
+            }
+
             var purposeA = "Password Protection";
-            var purposeB = $"Profile: {profileId}";
+            var purposeB = $"User: {userId}";
 
             byte[] unprotectedBytes = Encoding.UTF8.GetBytes(profilePassword);
             byte[] protectedBytes = MachineKey.Protect(unprotectedBytes, purposeA, purposeB);
@@ -24,10 +29,15 @@ namespace PasswordManager.Library.Internal.Encryption
             return protectedText;
         }
 
-        public static string DecryptPassword(string encryptedPassword, int profileId)
+        public static string DecryptPassword(string encryptedPassword, string userId)
         {
+            if (string.IsNullOrEmpty(userId))
+            {
+                throw new ArgumentException("Cannot decrypt password without proper userId.");
+            }
+
             var purposeA = "Password Protection";
-            var purposeB = $"Profile: {profileId}";
+            var purposeB = $"User: {userId}";
 
             byte[] protectedBytes = Convert.FromBase64String(encryptedPassword);
             byte[] unprotectedBytes = MachineKey.Unprotect(protectedBytes, purposeA, purposeB);

--- a/src/PasswordManager.App/Controllers/ProfileController.cs
+++ b/src/PasswordManager.App/Controllers/ProfileController.cs
@@ -83,11 +83,13 @@ namespace PasswordManager.App.Controllers
             if (profile.HasPasswordChanged)
                 profile.LastUpdated = DateTime.Now;
 
+            string userId = User.Identity.GetUserId();
             int catId = (int)profile.Category;
 
             var data = new ProfileDataModel()
             {
                 Id = id,
+                UserId = userId,
                 CategoryId = catId,
                 Title = profile.Title,
                 Website = profile.Website,


### PR DESCRIPTION
Fixes a profile retrieval bug that throws exception when decrypting password field. Purpose string for created profiles was referencing the profileId, which was encrypted as zero since the model had not yet submitted to the db at the time of encryption.