### PR TITLE
Add Accounts Settings Page & Deletion

### DIFF
--- a/lib/PasswordManager.Library/DataAccess/IProfileData.cs
+++ b/lib/PasswordManager.Library/DataAccess/IProfileData.cs
@@ -9,5 +9,6 @@ namespace PasswordManager.Library.DataAccess
         void InsertProfileForUser(ProfileDataModel data);
         void UpdateProfile(ProfileDataModel data);
         void DeleteProfile(int id);
+        void DeleteProfilesForUser(string userId);
     }
 }

--- a/lib/PasswordManager.Library/DataAccess/ProfileData.cs
+++ b/lib/PasswordManager.Library/DataAccess/ProfileData.cs
@@ -71,5 +71,10 @@ namespace PasswordManager.Library.DataAccess
         {
             _dataAccess.SaveData(DboNames.spDeleteProfile, DboNames.dboNameAzure, new { @id = id });
         }
+
+        public void DeleteProfilesForUser(string userId)
+        {
+            _dataAccess.SaveData(DboNames.spDeleteProfilesForUser, DboNames.dboNameAzure, new { @userId = userId });
+        }
     }
 }

--- a/lib/PasswordManager.Library/Internal/DataAccess/DboNames.cs
+++ b/lib/PasswordManager.Library/Internal/DataAccess/DboNames.cs
@@ -11,6 +11,8 @@ namespace PasswordManager.Library.Internal.DataAccess
 
         public const string spGetAllUsers = "dbo.spUser_GetAll";
         public const string spGetProfilesByUser = "dbo.spProfiles_GetForUser";
+        public const string spDeleteProfilesForUser = "dbo.spProfiles_DeleteAllForUser";
+
         public const string spInsertProfileByUser = "dbo.spProfiles_InsertForUser";
         public const string spUpdateProfile = "dbo.spProfiles_UpdateProfile";
         public const string spDeleteProfile = "dbo.spProfiles_DeleteProfile";

--- a/src/PasswordManager.App/Content/base-theme.css
+++ b/src/PasswordManager.App/Content/base-theme.css
@@ -206,11 +206,47 @@ textarea {
 }
 /*#endregion*/
 
-/* Content */
+/*#region Content */
 .content-container {
     margin: 0 auto;
     width: 80vw;
 }
+
+.acct-set {
+    margin: 24px 0;
+}
+
+.link-to-btn {
+    padding: 4px 6px;
+    text-decoration: none;
+}
+.toggle-group {
+    max-width: 80%;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+}
+
+.toggle-container {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.2s linear;
+    padding: 0 6px;
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    align-items: center;
+}
+
+.toggle-container p {
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 16px 0 0;
+    color: var(--secondary-text);
+    font-size: 24px;
+}
+/*#endregion */
 
 /*#region Navbar */
 .nav-background,

--- a/src/PasswordManager.App/Content/base-theme.css
+++ b/src/PasswordManager.App/Content/base-theme.css
@@ -236,9 +236,15 @@ textarea {
     align-items: center;
 }
 
+.navbar-group ul {
+    display: flex;
+    justify-content: flex-end;
+}
+
 .navbar-group li {
     list-style-type: none;
     text-decoration: none;
+    margin: auto 6px;
 }
 
 .navbar-group a {

--- a/src/PasswordManager.App/Controllers/ManageController.cs
+++ b/src/PasswordManager.App/Controllers/ManageController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNet.Identity;
 using Microsoft.AspNet.Identity.Owin;
 using Microsoft.Owin.Security;
 using PasswordManager.App.Models;
+using PasswordManager.Library.DataAccess;
 
 namespace PasswordManager.App.Controllers
 {
@@ -73,6 +74,26 @@ namespace PasswordManager.App.Controllers
                 BrowserRemembered = await AuthenticationManager.TwoFactorBrowserRememberedAsync(userId)
             };
             return View(model);
+        }
+        
+        /// <summary>
+        /// Delete currently logged user.
+        /// </summary>
+        /// <returns></returns>
+        // POST: /Manage/Delete
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<ActionResult> DeleteAccount()
+        {
+            IProfileData _profileData = new ProfileData();
+            string userId = User.Identity.GetUserId();
+            var user = await UserManager.FindByIdAsync(userId);
+            // Delete profiles associated with users
+            _profileData.DeleteProfilesForUser(userId);
+            // Delete aspNetUser
+            await UserManager.DeleteAsync(user);
+
+            return RedirectToAction("Login", "Account");
         }
 
         //

--- a/src/PasswordManager.App/PasswordManager.App.csproj
+++ b/src/PasswordManager.App/PasswordManager.App.csproj
@@ -234,7 +234,7 @@
     <Content Include="Views\Shared\Lockout.cshtml" />
     <Content Include="Views\Profile\Index.cshtml" />
     <Content Include="Views\Shared\_LayoutBanner.cshtml" />
-    <Content Include="Views\Profile\_Layout.cshtml" />
+    <Content Include="Views\Shared\_Layout.cshtml" />
     <Content Include="Views\Profile\_CreatePartial.cshtml" />
     <Content Include="Views\Profile\_DetailsPartial.cshtml" />
     <Content Include="Views\Profile\_EditPartial.cshtml" />

--- a/src/PasswordManager.App/PasswordManager.App.csproj
+++ b/src/PasswordManager.App/PasswordManager.App.csproj
@@ -239,6 +239,7 @@
     <Content Include="Views\Profile\_DetailsPartial.cshtml" />
     <Content Include="Views\Profile\_EditPartial.cshtml" />
     <Content Include="Views\Profile\_DeletePartial.cshtml" />
+    <Content Include="Views\Manage\_DeleteAccountPartial.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />

--- a/src/PasswordManager.App/Scripts/main.js
+++ b/src/PasswordManager.App/Scripts/main.js
@@ -9,6 +9,29 @@ let editForm; // Profile details for value reversion in case of edit cancel
 collapseAll();
 linkCategoriesToProfiles();
 linkProfileTitlesToSubmitBtns();
+resetToggleContainers();
+
+function resetToggleContainers() {
+    const groups = Array.from(document.querySelectorAll('.toggle-group'));
+    groups.forEach(group => {
+        const containers = Array.from(group.querySelectorAll('.toggle-container'));
+        containers.forEach((container, index) => {
+            if (index == 0) {
+                container.style.maxHeight = container.scrollHeight + 30 + 'px';
+            }
+            else {
+                container.style.maxHeight = 0;
+            }
+        });
+    });
+}
+
+function cycleToggleContainers(toggleGroupElement, currentIndex, targetIndex) {
+    const containers = Array.from(toggleGroupElement.querySelectorAll('.toggle-container'));
+
+    containers[currentIndex].style.maxHeight = 0;
+    containers[targetIndex].style.maxHeight = containers[targetIndex].scrollHeight + 30 + 'px';
+}
 
 // When input for title textbox changes, the submit button is toggled 'disabled' depending on whether input exists
 function linkProfileTitlesToSubmitBtns() {

--- a/src/PasswordManager.App/Views/Manage/Index.cshtml
+++ b/src/PasswordManager.App/Views/Manage/Index.cshtml
@@ -1,6 +1,7 @@
 ﻿@model PasswordManager.App.Models.IndexViewModel
 @{
     ViewBag.Title = "Manage";
+    Layout = "~/Views/Shared/_Layout.cshtml";
 }
 
 <h2>@ViewBag.Title.</h2>

--- a/src/PasswordManager.App/Views/Manage/Index.cshtml
+++ b/src/PasswordManager.App/Views/Manage/Index.cshtml
@@ -4,85 +4,13 @@
     Layout = "~/Views/Shared/_Layout.cshtml";
 }
 
-<h2>@ViewBag.Title.</h2>
+<h2>Manage Account</h2>
 
 <p class="text-success">@ViewBag.StatusMessage</p>
 <div>
     <h4>Change your account settings</h4>
     <hr />
-    <dl class="dl-horizontal">
-        <dt>Password:</dt>
-        <dd>
-            [
-            @if (Model.HasPassword)
-            {
-                @Html.ActionLink("Change your password", "ChangePassword")
-            }
-            else
-            {
-                @Html.ActionLink("Create", "SetPassword")
-            }
-            ]
-        </dd>
-        <dt>External Logins:</dt>
-        <dd>
-            @Model.Logins.Count [
-            @Html.ActionLink("Manage", "ManageLogins") ]
-        </dd>
-        @*
-            Phone Numbers can used as a second factor of verification in a two-factor authentication system.
-             
-             See <a href="https://go.microsoft.com/fwlink/?LinkId=403804">this article</a>
-                for details on setting up this ASP.NET application to support two-factor authentication using SMS.
-             
-             Uncomment the following block after you have set up two-factor authentication
-        *@
-        @*  
-            <dt>Phone Number:</dt>
-            <dd>
-                @(Model.PhoneNumber ?? "None")
-                @if (Model.PhoneNumber != null)
-                {
-                    <br />
-                    <text>[&nbsp;&nbsp;@Html.ActionLink("Change", "AddPhoneNumber")&nbsp;&nbsp;]</text>
-                    using (Html.BeginForm("RemovePhoneNumber", "Manage", FormMethod.Post, new { @class = "form-horizontal", role = "form" }))
-                    {
-                        @Html.AntiForgeryToken()
-                        <text>[<input type="submit" value="Remove" class="btn-link" />]</text>
-                    }
-                }
-                else
-                {
-                    <text>[&nbsp;&nbsp;@Html.ActionLink("Add", "AddPhoneNumber")
-                }
-            </dd>
-        *@
-        <dt>Two-Factor Authentication:</dt>
-        <dd>
-            <p>
-                There are no two-factor authentication providers configured. See <a href="https://go.microsoft.com/fwlink/?LinkId=403804">this article</a>
-                for details on setting up this ASP.NET application to support two-factor authentication.
-            </p>
-            @*@if (Model.TwoFactor)
-                {
-                    using (Html.BeginForm("DisableTwoFactorAuthentication", "Manage", FormMethod.Post, new { @class = "form-horizontal", role = "form" }))
-                    {
-                        @Html.AntiForgeryToken()
-                        <text>Enabled
-                        <input type="submit" value="Disable" class="btn btn-link" />
-                        </text>
-                    }
-                }
-                else
-                {
-                    using (Html.BeginForm("EnableTwoFactorAuthentication", "Manage", FormMethod.Post, new { @class = "form-horizontal", role = "form" }))
-                    {
-                        @Html.AntiForgeryToken()
-                        <text>Disabled
-                        <input type="submit" value="Enable" class="btn btn-link" />
-                        </text>
-                    }
-                }*@
-        </dd>
-    </dl>
+    <div class="acct-set">
+        @Html.Partial("_DeleteAccountPartial")
+    </div>
 </div>

--- a/src/PasswordManager.App/Views/Manage/_DeleteAccountPartial.cshtml
+++ b/src/PasswordManager.App/Views/Manage/_DeleteAccountPartial.cshtml
@@ -1,0 +1,15 @@
+﻿
+<h3>Deleting your account will permanently delete your account information and all profiles.</h3>
+<div class="toggle-group">
+    <div class="toggle-container">
+        <button class="profile-btn" onclick="cycleToggleContainers(this.parentNode.parentNode, 0, 1)">Delete Account</button>
+    </div>
+    @using (Html.BeginForm("DeleteAccount", "Manage", FormMethod.Post, new { @class = "toggle-container" }))
+    {
+        @Html.AntiForgeryToken()
+
+        <p>Are you sure you want to delete this account?</p>
+        <input type="submit" value="Delete" class="profile-btn" />
+        <button type="button" class="profile-btn" onclick="cycleToggleContainers(this.parentNode.parentNode, 1, 0)">Cancel</button>
+    }
+</div>

--- a/src/PasswordManager.App/Views/Profile/Index.cshtml
+++ b/src/PasswordManager.App/Views/Profile/Index.cshtml
@@ -2,7 +2,7 @@
 
 @{
     ViewBag.Title = "Index";
-    Layout = "~/Views/Profile/_Layout.cshtml";
+    Layout = "~/Views/Shared/_Layout.cshtml";
 }
 
 <h2>User Profiles</h2>

--- a/src/PasswordManager.App/Views/Shared/_Layout.cshtml
+++ b/src/PasswordManager.App/Views/Shared/_Layout.cshtml
@@ -16,6 +16,12 @@
             <h2>Password Manager</h2>
             <ul>
                 <li>
+                    @Html.ActionLink("Profiles", "Index", "Profile")
+                </li>
+                <li>
+                    @Html.ActionLink("Account", "Index", "Manage")
+                </li>
+                <li>
                     @using (Html.BeginForm("LogOff", "Account", FormMethod.Post, new { id = "logoutForm" }))
                     {
                         @Html.AntiForgeryToken()

--- a/src/PasswordManager.Data/PasswordManager.Data.sqlproj
+++ b/src/PasswordManager.Data/PasswordManager.Data.sqlproj
@@ -156,6 +156,7 @@
     <Build Include="dbo\StoredProcedures\spProfiles_InsertForUser.sql" />
     <Build Include="dbo\StoredProcedures\spProfiles_UpdateProfile.sql" />
     <Build Include="dbo\StoredProcedures\spProfiles_DeleteProfile.sql" />
+    <Build Include="dbo\StoredProcedures\spProfiles_DeleteAllForUser.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="PublishLocations\PasswordManager.Data.publish.xml" />

--- a/src/PasswordManager.Data/dbo/StoredProcedures/spProfiles_DeleteAllForUser.sql
+++ b/src/PasswordManager.Data/dbo/StoredProcedures/spProfiles_DeleteAllForUser.sql
@@ -1,0 +1,9 @@
+﻿CREATE PROCEDURE [dbo].[spProfiles_DeleteAllForUser]
+	@userId NVARCHAR(128)
+AS
+begin
+	set nocount on;
+
+	delete from [dbo].[Profiles]
+	where UserId = @userId;
+end


### PR DESCRIPTION
Issue:
 - Users cannot delete their account and have no place to adjust account settings.

Solution:
 - Add account settings page.
 - Add option to permanently delete user account and all associated profiles.

Strategy:
 - Add 'account' view.
 - Add navigation between 'account' and 'profiles' views.
 - Add functionality for deleting user and profiles from db.